### PR TITLE
Fixed HTML character encoding

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <title>NetworkBoot.org</title>
-<meta encoding="UTF-8">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 </head>
 <body>
 


### PR DESCRIPTION
The <meta encoding="UTF-8"> tag did not work with Google Chrome v26.
According to wikipedia the HTTP Content-Type equivalent meta tag can be
used:

http://en.wikipedia.org/wiki/Character_encodings_in_HTML#Specifying_the_document.27s_character_encoding

Now Robin's last name is rendered correctly.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
